### PR TITLE
nmap2ivil: parse multiple addresses for host

### DIFF
--- a/bin/nmap2ivil
+++ b/bin/nmap2ivil
@@ -73,6 +73,7 @@ my $nmap = XMLin($infile,
 			   					 'osmatch', 
 			   					 'port', 
 			   					 'extrareasons',
+			   					 'address',
 			   					 'hostname',
 			   					 'extraports',
 			   					 'script',
@@ -148,7 +149,21 @@ print "Iterating over hosts\n" if $verbose;
 
 foreach my $host ( @{$nmap->{host}} ) {
 	# Lets get the basic host parameters first
-	my $ip = $host->{address}->{addr};	# This values stores the IP address
+	my $ip = "";
+	for my $addr ( @{$host->{address}} ) {
+		print "Found addr $addr->{addr} with type $addr->{addrtype}\n" if $verbose;
+		if ( $addr->{addrtype} eq "ipv6" ) {
+			$ip = $addr->{addr};	# This values stores the IP address
+		} elsif ( $addr->{addrtype} eq "ipv4" ) {
+			$ip = $addr->{addr};	# This values stores the IP address
+		}
+	}
+
+	if ( $ip eq "" ) {
+		print "Failed to find IPv4/IPv6 address for host '$host->{hostnames}->{hostname}[0]->{name}'\n";
+		next;
+	}
+
 	print "IP: $ip\n" if $verbose;
 	foreach my $item ( keys %{$host} ) {
 		# O.K. lets go through all findings


### PR DESCRIPTION
In some cases nmap generates address nodes for both IP and hw (mac).
Parse address as array and search for IPv4/IPv6 to avoid the problem.