### PR TITLE
Fix NBE report parsing with OpenVAS.

### DIFF
--- a/bin/do-scan
+++ b/bin/do-scan
@@ -69,6 +69,8 @@ print "\nDone\n" unless $quiet;
 exit();
 
 sub help() {
+	my $message = shift;
+	if( $message ) print "Error: $message\n";
 	print "
 Usage: do-scan --workspace <workspace name> --scan <scan name> [--verbose] 
                [--quiet] [--help]

--- a/bin/do-scan
+++ b/bin/do-scan
@@ -70,7 +70,7 @@ exit();
 
 sub help() {
 	my $message = shift;
-	if( $message ) print "Error: $message\n";
+	if( $message ) { print "Error: $message\n" };
 	print "
 Usage: do-scan --workspace <workspace name> --scan <scan name> [--verbose] 
                [--quiet] [--help]

--- a/scanners/OpenVAS6/scan
+++ b/scanners/OpenVAS6/scan
@@ -314,10 +314,6 @@ my $nbe_report = $1;
 
 print "nbe_report: $nbe_report\n" if $verbose >1;
 
-my $result_index = index($nbe_report, "</report>");
-print "result_index file end : $result_index \n" if $verbose >1;
-$nbe_report = substr($nbe_report, 0, $result_index);
-
 # For investigations : in case verbose >2, dump files to disk
 if ($verbose >2) {
 open (Rawfile,">$tempfile.raw") or die "cannot open file $tempfile.raw";

--- a/scanners/OpenVAS6/scan
+++ b/scanners/OpenVAS6/scan
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright 2015 Fabien Guillaume (FGuillaume), Frank Breedijk, Andrey Danin
+# Copyright 2015 Fabien Guillaume (FGuillaume), Frank Breedijk, Andrey Danin, Floris Kraak (randakar)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scanners/OpenVAS6/scan
+++ b/scanners/OpenVAS6/scan
@@ -309,12 +309,12 @@ print "Retrieve report result code : $request_code_result \n" if $verbose >0;
 
 
 # extract base64 nbe from xmlresult string
-my $result_index = index($xmlrequest, "\">", 120);
-$result_index +=2;
-print "result_index : $result_index\n" if $verbose >1;
-my $nbe_report=substr($xmlrequest, $result_index);
+$xmlrequest =~ m#\>([^<]+)</report>#;
+my $nbe_report = $1;
 
-$result_index = index($nbe_report, "</report>");
+print "nbe_report: $nbe_report\n" if $verbose >1;
+
+my $result_index = index($nbe_report, "</report>");
 print "result_index file end : $result_index \n" if $verbose >1;
 $nbe_report = substr($nbe_report, 0, $result_index);
 


### PR DESCRIPTION
With current debian versions of OpenVAS retrieving the report breaks. Original code was very fragile, in fact.
Replaced the search for the report content with a regular expression that should not break so easily.

Note: The OpenVAS XML output does not validate as proper XML.
That's the root of this problem - since it can't be validated the script resorts to manual text parsing, which naturally breaks when the output format changes even slightly.
Note2: This code does not check if we actually got a result. That still needs to be added, but if that is going to be done it should be done with *everything* in this script, not just the bit that gets the report from OpenVAS's response.